### PR TITLE
improve subtitle's readability

### DIFF
--- a/SwiftUIMindBlowing/Base/UI/ExampleCellView.swift
+++ b/SwiftUIMindBlowing/Base/UI/ExampleCellView.swift
@@ -18,7 +18,6 @@ struct ExampleCellView: View {
                 .lineLimit(nil)
                 .font(.subheadline)
                 .foregroundColor(Color.gray)
-                .minimumScaleFactor(0.5)
         }
     }
 }
@@ -26,7 +25,7 @@ struct ExampleCellView: View {
 #if DEBUG
 struct ExampleCellView_Previews: PreviewProvider {
     static var previews: some View {
-        ExampleCellView(title: "Title", subtitle: "Subtitle", sourceCodeURL: "https://www.github.com")
+        ExampleCellView(title: "Title", subtitle: "A view that arranges its children in a horizontal line. A view that arranges its children in a horizontal line.", sourceCodeURL: "https://www.github.com")
     }
 }
 #endif


### PR DESCRIPTION
Hi. Just having fun going through contents. They are awesome! Thanks.

Here is a small improvement to UI. I think it was too small for most people.

|before|after|
|---|---|
| ![BasicContentView_swift_before](https://user-images.githubusercontent.com/6007952/68084611-42672800-fe7b-11e9-9bcc-60a56e08033d.jpg) | ![BasicContentView_swift](https://user-images.githubusercontent.com/6007952/68084612-42ffbe80-fe7b-11e9-80d1-8fc381ae8b71.jpg) |